### PR TITLE
Add Missing Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ The following modules are considered public API ready for consumption:
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/.../mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib?doc).
 
 ## Need Help?
 

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@
 
 The following modules are considered public API ready for consumption:
 
-- [`@enzastdlib/async`](./async) — Utilities for working with asynchronous and `Promise`-based code.
-- [`@enzastdlib/collections`](./collections) — Utilities for working with collections like arrays and records.
-- [`@enzastdlib/commands`](./commands) — Create command line tools with validation powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
-- [`@enzastdlib/decorators`](./decorators) — Create function decorators that access metadata with a streamlined API.
-- [`@enzastdlib/environment`](./environment) — Parse and validate both environment variables and dotenv files powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
-- [`@enzastdlib/errors`](./errors) — General error objects that are used across `enzastdlib`.
-- [`@enzastdlib/path`](./events) — Create typed events with a typed version of `EventTarget`.
-- [`@enzastdlib/json5`](./json5) — Parse JSON5 documents and expressions.
-- [`@enzastdlib/os`](./os) — Utilities for abstracting away operating system specifics.
-- [`@enzastdlib/path`](./path) — Utilities for working with file system paths and URLs.
-- [`@enzastdlib/realm`](./realm) — Create custom JavaScript and TypeScript execution environments.
-- [`@enzastdlib/rpc`](./rpc) — Contains supplemental typing for creating fully typed and validated RPC clients and servers.
-- [`@enzastdlib/rpc-http`](./rpc-http) — Create fully typed and validated RPC clients and servers using HTTP as the transport.
-- [`@enzastdlib/rpc-messageport`](./rpc-messageport) — Create fully typed and validated RPC clients and servers using [`MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort)-like API instances as the transport.
-- [`@enzastdlib/rpc-protocol`](./rpc-protocol) — Create fully typed and validated RPC clients and servers powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
-- [`@enzastdlib/rpc-streams`](./rpc-streams) — Create fully typed and validated RPC clients and servers using a pair of [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) / [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) instances as the transport.
-- [`@enzastdlib/schema`](./schema) — Create easy to use validators powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
-- [`@enzastdlib/strings`](./strings) — Utilities for working with strings.
-- [`@enzastdlib/testing`](./testing) — Utilities for working with Deno's testing API.
+- [`@enzastdlib/async`](https://deno.land/x/enzastdlib/async/mod.ts?doc) — Utilities for working with asynchronous and `Promise`-based code.
+- [`@enzastdlib/collections`](https://deno.land/x/enzastdlib/collections/mod.ts?doc) — Utilities for working with collections like arrays and records.
+- [`@enzastdlib/commands`](https://deno.land/x/enzastdlib/commands/mod.ts?doc) — Create command line tools with validation powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
+- [`@enzastdlib/decorators`](https://deno.land/x/enzastdlib/decorators/mod.ts?doc) — Create function decorators that access metadata with a streamlined API.
+- [`@enzastdlib/environment`](https://deno.land/x/enzastdlib/environment/mod.ts?doc) — Parse and validate both environment variables and dotenv files powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
+- [`@enzastdlib/errors`](https://deno.land/x/enzastdlib/errors/mod.ts?doc) — General error objects that are used across `enzastdlib`.
+- [`@enzastdlib/path`](https://deno.land/x/enzastdlib/events/mod.ts?doc) — Create typed events with a typed version of `EventTarget`.
+- [`@enzastdlib/json5`](https://deno.land/x/enzastdlib/json5/mod.ts?doc) — Parse JSON5 documents and expressions.
+- [`@enzastdlib/os`](https://deno.land/x/enzastdlib/os/mod.ts?doc) — Utilities for abstracting away operating system specifics.
+- [`@enzastdlib/path`](https://deno.land/x/enzastdlib/path/mod.ts?doc) — Utilities for working with file system paths and URLs.
+- [`@enzastdlib/realm`](https://deno.land/x/enzastdlib/realm/mod.ts?doc) — Create custom JavaScript and TypeScript execution environments.
+- [`@enzastdlib/rpc`](https://deno.land/x/enzastdlib/rpc/mod.ts?doc) — Contains supplemental typing for creating fully typed and validated RPC clients and servers.
+- [`@enzastdlib/rpc-http`](https://deno.land/x/enzastdlib/rpc-http/mod.ts?doc) — Create fully typed and validated RPC clients and servers using HTTP as the transport.
+- [`@enzastdlib/rpc-messageport`](https://deno.land/x/enzastdlib/rpc-messageport/mod.ts?doc) — Create fully typed and validated RPC clients and servers using [`MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort)-like API instances as the transport.
+- [`@enzastdlib/rpc-protocol`](https://deno.land/x/enzastdlib/rpc-protocol/mod.ts?doc) — Create fully typed and validated RPC clients and servers powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
+- [`@enzastdlib/rpc-streams`](https://deno.land/x/enzastdlib/rpc-streams/mod.ts?doc) — Create fully typed and validated RPC clients and servers using a pair of [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) / [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) instances as the transport.
+- [`@enzastdlib/schema`](https://deno.land/x/enzastdlib/schema/mod.ts?doc) — Create easy to use validators powered by [JSON Schema 2019-09](https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8).
+- [`@enzastdlib/strings`](https://deno.land/x/enzastdlib/strings/mod.ts?doc) — Utilities for working with strings.
+- [`@enzastdlib/testing`](https://deno.land/x/enzastdlib/testing/mod.ts?doc) — Utilities for working with Deno's testing API.
 
 ## Importing
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,4 +2,8 @@
 
 - Create API examples via the `@example` JSDoc annotation for all public API.
 
+- Add possible thrown exceptions to all public API docs.
+
+- Add Deno flags used to all public API docs.
+
 - Vendor external requirements.

--- a/async/README.md
+++ b/async/README.md
@@ -4,8 +4,10 @@ Utilities for working with asynchronous and `Promise`-based code.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/async/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/async/mod.ts?doc).

--- a/async/iterable.ts
+++ b/async/iterable.ts
@@ -10,8 +10,8 @@
  * @example
  *
  * ```typescript
- * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
- * import { arrayFromIterable } from "https://deno.land/x/enzastdlib/async/mod.ts";
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { arrayFromIterable } from 'https://deno.land/x/enzastdlib/async/mod.ts';
  *
  * async function* myGenerator(): AsyncGenerator<number> {
  *     yield Promise.resolve(1);

--- a/async/iterable.ts
+++ b/async/iterable.ts
@@ -1,3 +1,31 @@
+/**
+ * Returns all values collected from the `iterable` in an array.
+ *
+ * > **NOTE**: This function is the equivilent of [`Array.fromAsync`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync)
+ * > if it available in your runtime use that instead.
+ *
+ * @param iterable
+ * @returns
+ *
+ * @example
+ *
+ * ```typescript
+ * import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+ * import { arrayFromIterable } from "https://deno.land/x/enzastdlib/async/mod.ts";
+ *
+ * async function* myGenerator(): AsyncGenerator<number> {
+ *     yield Promise.resolve(1);
+ *     yield Promise.resolve(2);
+ *     yield Promise.resolve(3);
+ * }
+ *
+ * const generator = myGenerator();
+ *
+ * const numbers = await arrayFromIterable(generator);
+ *
+ * assertEquals(numbers, [1, 2, 3]);
+ * ```
+ */
 export async function arrayFromIterable<Value>(
 	iterable: AsyncIterable<Value>,
 ): Promise<Value[]> {

--- a/async/iterable.ts
+++ b/async/iterable.ts
@@ -8,7 +8,6 @@
  * @returns
  *
  * @example
- *
  * ```typescript
  * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
  * import { arrayFromIterable } from 'https://deno.land/x/enzastdlib/async/mod.ts';

--- a/async/promise.ts
+++ b/async/promise.ts
@@ -3,7 +3,7 @@
  *
  * @example
  * ```typescript
- * import type { Promisify } from "https://deno.land/x/enzastdlib/async/mod.ts";
+ * import type { Promisify } from 'https://deno.land/x/enzastdlib/async/mod.ts';
  *
  * function plainFunction(): number {
  *     return 1;
@@ -25,16 +25,19 @@ export type Promisify<Value> = Value extends Promise<unknown> ? Value
  * @example
  *
  * ```typescript
- * import { assertEquals, assertInstanceOf } from "https://deno.land/std/testing/asserts.ts";
- * import { makePromise } from "https://deno.land/x/enzastdlib/async/mod.ts";
- * import { assertTypeOf } from "https://deno.land/x/enzastdlib/testing/mod.ts";
+ * import {
+ *     assertEquals,
+ *     assertInstanceOf,
+ * } from 'https://deno.land/std/testing/asserts.ts';
+ * import { makePromise } from 'https://deno.land/x/enzastdlib/async/mod.ts';
+ * import { assertTypeOf } from 'https://deno.land/x/enzastdlib/testing/mod.ts';
  *
- * const {promise, resolve, reject} = makePromise<number>();
+ * const { promise, resolve, reject } = makePromise<number>();
  *
  * assertInstanceOf(promise, Promise);
  *
- * assertTypeOf(resolve, "function");
- * assertTypeOf(reject, "function");
+ * assertTypeOf(resolve, 'function');
+ * assertTypeOf(reject, 'function');
  *
  * resolve(42);
  *

--- a/async/promise.ts
+++ b/async/promise.ts
@@ -23,7 +23,6 @@ export type Promisify<Value> = Value extends Promise<unknown> ? Value
  * @returns
  *
  * @example
- *
  * ```typescript
  * import {
  *     assertEquals,

--- a/async/promise.ts
+++ b/async/promise.ts
@@ -1,5 +1,18 @@
 /**
  * Returns type wrapped in a `Promise` if not already a `Promise`-wrapped value.
+ *
+ * @example
+ * ```typescript
+ * import type { Promisify } from "https://deno.land/x/enzastdlib/async/mod.ts";
+ *
+ * function plainFunction(): number {
+ *     return 1;
+ * }
+ *
+ * type plainFunctionReturn = ReturnType<typeof plainFunction>; // `number`
+ *
+ * type plainFunctionReturnPromisified = Promisify<plainFunctionReturn>; // `Promise<number>`
+ * ```
  */
 export type Promisify<Value> = Value extends Promise<unknown> ? Value
 	: Promise<Value>;
@@ -8,6 +21,25 @@ export type Promisify<Value> = Value extends Promise<unknown> ? Value
  * Returns a `Promise` instance along with its resolve and reject functions.
  *
  * @returns
+ *
+ * @example
+ *
+ * ```typescript
+ * import { assertEquals, assertInstanceOf } from "https://deno.land/std/testing/asserts.ts";
+ * import { makePromise } from "https://deno.land/x/enzastdlib/async/mod.ts";
+ * import { assertTypeOf } from "https://deno.land/x/enzastdlib/testing/mod.ts";
+ *
+ * const {promise, resolve, reject} = makePromise<number>();
+ *
+ * assertInstanceOf(promise, Promise);
+ *
+ * assertTypeOf(resolve, "function");
+ * assertTypeOf(reject, "function");
+ *
+ * resolve(42);
+ *
+ * assertEquals(await promise, 42);
+ * ```
  */
 export function makePromise<Value = void>(): {
 	promise: Promise<Value>;

--- a/collections/README.md
+++ b/collections/README.md
@@ -4,8 +4,10 @@ Utilities for working with collections like arrays and records.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/collections/mod.ts?doc).

--- a/collections/class.ts
+++ b/collections/class.ts
@@ -4,7 +4,6 @@ import { OmitValues, PickValues } from './object.ts';
  * Returns an `Object` containing all the methods of a `Class`.
  *
  * @example
- *
  * ```typescript
  * import type { MethodsOf } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *
@@ -34,7 +33,6 @@ export type MethodsOf<Cls> = PickValues<
  * Returns an `Object` containing all the properties of a `Class`.
  *
  * @example
- *
  * ```typescript
  * import type { PropertiesOf } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *

--- a/collections/class.ts
+++ b/collections/class.ts
@@ -2,6 +2,26 @@ import { OmitValues, PickValues } from './object.ts';
 
 /**
  * Returns an `Object` containing all the methods of a `Class`.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { MethodsOf } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * class MyClass {
+ *     myProperty = false;
+ *
+ *     methodOne(): number {
+ * 	       return 42;
+ *     }
+ *
+ *     methodTwo(): string {
+ *         return "Hello World";
+ *     }
+ * }
+ *
+ * type MyMethods = MethodsOf<MyClass>; // `{ methodOne: () => number; methodTwo: () => string; }`
+ * ```
  */
 export type MethodsOf<Cls> = PickValues<
 	Cls,
@@ -12,6 +32,26 @@ export type MethodsOf<Cls> = PickValues<
 
 /**
  * Returns an `Object` containing all the properties of a `Class`.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { PropertiesOf } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * class MyClass {
+ *     myProperty = false;
+ *
+ *     methodOne(): number {
+ * 	       return 42;
+ *     }
+ *
+ *     methodTwo(): string {
+ *         return "Hello World";
+ *     }
+ * }
+ *
+ * type MyProperties = PropertiesOf<MyClass>; // `{ myProperty: boolean; }`
+ * ```
  */
 export type PropertiesOf<Cls> = OmitValues<
 	Cls,

--- a/collections/object.ts
+++ b/collections/object.ts
@@ -1,28 +1,92 @@
 /**
- * Represents an `Object` that has no properties.
+ * Represents an `Object` type that has no properties.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { EmptyObject } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * type X = EmptyObject; // `{ [x: string]: never; [x: number]: never; [x: symbol]: never }`
+ * ```
  */
 export type EmptyObject = Record<PropertyKey, never>;
 
 /**
- * Returns an `Object` where properties with `Type` as the their typing are omitted.
+ * Returns an `Object` where members with the given type are picked into a new `Object` type.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { PickValues } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * const MY_CONSTANT_OBJECT = {
+ *     myBoolean: false,
+ *
+ *     myNumber: 42,
+ *
+ *     myString: 'Hello World',
+ *
+ *     otherNumber: 84,
+ * } as const;
+ *
+ * type FilteredValues = PickValues<typeof MY_CONSTANT_OBJECT, number>; // `{ readonly myNumber: 42; readonly otherNumber: 84; }`
  */
 export type PickValues<Obj, Value> = {
 	[Key in keyof Obj as Obj[Key] extends Value ? Key : never]: Obj[Key];
 };
 
 /**
- * Returns an `Object` where properties with `Type` as the their typing are omitted.
+ * Returns an `Object` where members with the given type are omitted from a new `Object` type.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { OmitValues } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * const MY_CONSTANT_OBJECT = {
+ *     myBoolean: false,
+ *
+ *     myNumber: 42,
+ *
+ *     myString: 'Hello World',
+ *
+ *     otherNumber: 84,
+ * } as const;
+ *
+ * type FilteredValues = OmitValues<typeof MY_CONSTANT_OBJECT, number>; // `{ readonly myBoolean: false; readonly myString: "Hello World"; }`
  */
 export type OmitValues<Obj, Value> = {
 	[Key in keyof Obj as Obj[Key] extends Value ? never : Key]: Obj[Key];
 };
 
 /**
- * Returns all the values of an `Object` as a type union.
+ * Returns all the values of an `Object` as a type union of its values.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { ValueOf } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * const MY_CONSTANT_OBJECT = {
+ *     x: 1,
+ * 	   y: 2,
+ *     z: 3
+ * } as const;
+ *
+ * type MyValues = ValueOf<typeof MY_CONSTANT_OBJECT>; // `1 | 2 | 3`
+ * ```
  */
 export type ValueOf<Obj> = Obj[keyof Obj];
 
 /**
- * Represents an `Object` that has unknown properties.
+ * Represents an `Object` type that has unknown properties.
+ *
+ * @example
+ *
+ * ```typescript
+ * import type { UnknownObject } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
+ *
+ * type X = UnknownObject; // `{ [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown }`
+ * ```
  */
 export type UnknownObject = Record<PropertyKey, unknown>;

--- a/collections/object.ts
+++ b/collections/object.ts
@@ -2,7 +2,6 @@
  * Represents an `Object` type that has no properties.
  *
  * @example
- *
  * ```typescript
  * import type { EmptyObject } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *
@@ -15,7 +14,6 @@ export type EmptyObject = Record<PropertyKey, never>;
  * Returns an `Object` where members with the given type are picked into a new `Object` type.
  *
  * @example
- *
  * ```typescript
  * import type { PickValues } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *
@@ -39,7 +37,6 @@ export type PickValues<Obj, Value> = {
  * Returns an `Object` where members with the given type are omitted from a new `Object` type.
  *
  * @example
- *
  * ```typescript
  * import type { OmitValues } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *
@@ -63,7 +60,6 @@ export type OmitValues<Obj, Value> = {
  * Returns all the values of an `Object` as a type union of its values.
  *
  * @example
- *
  * ```typescript
  * import type { ValueOf } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *
@@ -82,7 +78,6 @@ export type ValueOf<Obj> = Obj[keyof Obj];
  * Represents an `Object` type that has unknown properties.
  *
  * @example
- *
  * ```typescript
  * import type { UnknownObject } from 'https://deno.land/x/enzastdlib/collections/mod.ts';
  *

--- a/commands/README.md
+++ b/commands/README.md
@@ -4,11 +4,13 @@ Create command line tools with validation powered by [JSON Schema 2019-09](https
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/commands/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/commands/mod.ts?doc).
 
 ## Dependencies
 

--- a/commands/exit_codes.ts
+++ b/commands/exit_codes.ts
@@ -10,8 +10,8 @@ export const EXIT_CODES = {
 	/**
 	 * Represents when the command was called successfully.
 	 *
-	 * **NOTE**: By default this value is used if no number
-	 * is returned by the commands callback.
+	 * > **NOTE**: By default this value is used if no number
+	 * > is returned by the commands callback.
 	 */
 	resolved: 0,
 

--- a/decorators/README.md
+++ b/decorators/README.md
@@ -4,8 +4,10 @@ Create function decorators that access metadata with a streamlined API.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/decorators/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/decorators/mod.ts?doc).

--- a/environment/README.md
+++ b/environment/README.md
@@ -4,11 +4,13 @@ Parse and validate both environment variables and dotenv files powered by [JSON 
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/environment/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/environment/mod.ts?doc).
 
 ## Compatibility
 

--- a/errors/README.md
+++ b/errors/README.md
@@ -4,8 +4,10 @@ General error objects that are used across `enzastdlib`.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/errors/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/errors/mod.ts?doc).

--- a/errors/internalerror.ts
+++ b/errors/internalerror.ts
@@ -1,6 +1,15 @@
 /**
- * Represents an exception regarding an error that occured within
- * the internals of a system.
+ * Represents an exception regarding an error that occured within the internals
+ * of a system.
+ *
+ * @example
+ * ```typescript
+ * import { InternalError } from 'https://deno.land/x/enzastdlib/errors/mod.ts';
+ *
+ * throw new InternalError(
+ *     'an exception occured while processing the http request',
+ * );
+ * ```
  */
 export class InternalError extends Error {
 	readonly name = InternalError.name;

--- a/errors/validationerror.ts
+++ b/errors/validationerror.ts
@@ -1,5 +1,14 @@
 /**
- * Represents an exception regarding validation of data or input.
+ * Represents an exception regarding user-facing validation of data or input.
+ *
+ * @example
+ * ```typescript
+ * import { ValidationError } from 'https://deno.land/x/enzastdlib/errors/mod.ts';
+ *
+ * throw new ValidationError(
+ *     'property \'MyInterface.myProperty\' was a \'string\', expected \'number\'',
+ * );
+ * ```
  */
 export class ValidationError extends Error {
 	readonly name = ValidationError.name;

--- a/events/README.md
+++ b/events/README.md
@@ -4,8 +4,10 @@ Create typed events with a typed version of `EventTarget`.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/events/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/events/mod.ts?doc).

--- a/events/eventtarget.ts
+++ b/events/eventtarget.ts
@@ -1,6 +1,13 @@
-export type TypedEventMap = Record<string, CustomEvent>;
+// **NOTE**: The method descriptions of `TypedEventTarget` was taken from
+// TypeScript's built-in descriptions of `EventTarget`.
 
-export type TypedEventListener<Event extends CustomEvent> =
+/**
+ * Represents the expected listener typing passed to `TypedEventTarget.addEventListener`
+ * and `TypedEventTarget.removeEventListener`.
+ *
+ * @private
+ */
+type TypedEventListener<Event extends CustomEvent> =
 	| ((
 		evt: Event,
 	) => void | Promise<void>)
@@ -8,11 +15,133 @@ export type TypedEventListener<Event extends CustomEvent> =
 		handleEvent(evt: Event): void | Promise<void>;
 	};
 
-export class TypedEventTarget<EventMap extends TypedEventMap>
+/**
+ * Represents a record of event names associated with their `CustomEvent`-derived
+ * classes.
+ *
+ * @example
+ * ```typescript
+ * class UpdateEvent extends CustomEvent<{ original: unknown, replacement: unknown }> {}
+ *
+ * // **NOTE**: While you can import this type and use `interface MyEvents extends TypedEventRecord`
+ * // you will lose autocomplete in IDEs.
+ * //
+ * // So this example is just showcasing the expected interface of `Record<string, CustomEvent>`.
+ * type MyEvents = {
+ *     update: UpdateEvent;
+ * };
+ * ```
+ */
+export type TypedEventRecord = Record<string, CustomEvent>;
+
+/**
+ * Represents a strongly-typed inheritable verison of the standard Web API `EventTarget`.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *     assertEquals,
+ *     assertInstanceOf,
+ * } from 'https://deno.land/std/testing/asserts.ts';
+ * import { TypedEventTarget } from 'https://deno.land/x/enzastdlib/events/mod.ts';
+ *
+ * interface UpdateEventDetail {
+ *     original: unknown;
+ *
+ *     replacement: unknown;
+ * }
+ *
+ * class UpdateEvent extends CustomEvent<UpdateEventDetail> {
+ *     constructor(detail: UpdateEventDetail) {
+ *         // **IMPORTANT**: Make sure to set the name of your event in the
+ *         // constructor to match the one located in your event record.
+ *         //
+ *         // Which in this case is `update`.
+ *         super('update', { detail });
+ *     }
+ * }
+ *
+ * type MyEvents = {
+ *     update: UpdateEvent;
+ * };
+ *
+ * class MyEventTarget extends TypedEventTarget<MyEvents> {}
+ *
+ * // **NOTE**: Alternatively you can just construct the `TypedEventTarget` without
+ * // using inheritence:
+ * //
+ * // const event_target = new TypedEventTarget<MyEvents>();
+ * const event_target = new MyEventTarget();
+ *
+ * assertInstanceOf(event_target, EventTarget);
+ *
+ * event_target.addEventListener('update', (event: UpdateEvent): void => {
+ *     assertInstanceOf(event, CustomEvent);
+ *
+ *     assertEquals(event.detail, {
+ *         original: 42,
+ *         replacement: 82,
+ *     });
+ * });
+ *
+ * const event = new UpdateEvent({
+ *     original: 42,
+ *     replacement: 84,
+ * });
+ *
+ * event_target.dispatchEvent(event);
+ * ```
+ */
+export class TypedEventTarget<EventRecord extends TypedEventRecord>
 	extends EventTarget {
-	addEventListener<Type extends keyof EventMap>(
+	/**
+	 * Appends an event listener for events whose type attribute value is type. The
+	 * callback argument sets the callback that will be invoked when the event is
+	 * dispatched.
+	 *
+	 * The options argument sets listener-specific options. For compatibility this
+	 * can be a boolean, in which case the method behaves exactly as if the value was
+	 * specified as options's capture.
+	 *
+	 * When set to true, options's capture prevents callback from being invoked when
+	 * the event's eventPhase attribute value is BUBBLING_PHASE. When false (or not present),
+	 * callback will not be invoked when event's eventPhase attribute value is
+	 * CAPTURING_PHASE. Either way, callback will be invoked if event's eventPhase
+	 * attribute value is AT_TARGET.
+	 *
+	 * When set to true, options's passive indicates that the callback will not
+	 * cancel the event by invoking preventDefault(). This is used to enable performance
+	 * optimizations described in § 2.8 Observing event listeners.
+	 *
+	 * When set to true, options's once indicates that the callback will only be
+	 * invoked once after which the event listener will be removed.
+	 *
+	 * The event listener is appended to target's event listener list and is not
+	 * appended if it has the same type, callback, and capture.
+	 *
+	 * @param type
+	 * @param listener
+	 * @param options
+	 *
+	 * @example
+	 * ```typescript
+	 * import { TypedEventTarget } from 'https://deno.land/x/enzastdlib/events/mod.ts';
+	 *
+	 * type MyEvents = {
+	 *     myEvent: CustomEvent<{ myValue: number }>;
+	 * };
+	 *
+	 * const event_target = new TypedEventTarget<MyEvents>();
+	 *
+	 * event_target.addEventListener(
+	 *     'myEvent',
+	 *     (event) => console.log(event.detail.myValue),
+	 * );
+	 * ```
+	 */
+	addEventListener<Type extends keyof EventRecord>(
 		type: Type,
-		listener: TypedEventListener<EventMap[Type]> | null,
+		listener: TypedEventListener<EventRecord[Type]> | null,
 		options?: boolean | AddEventListenerOptions | undefined,
 	): void {
 		super.addEventListener(
@@ -25,15 +154,64 @@ export class TypedEventTarget<EventMap extends TypedEventMap>
 		);
 	}
 
-	dispatchEvent<Event extends EventMap[keyof EventMap]>(
+	/**
+	 * Dispatches a synthetic event event to target and returns true if either event's
+	 * cancelable attribute value is false or its preventDefault() method was not
+	 * invoked, and false otherwise.
+	 *
+	 * @param event
+	 * @returns
+	 *
+	 * @example
+	 * ```typescript
+	 * import { TypedEventTarget } from 'https://deno.land/x/enzastdlib/events/mod.ts';
+	 *
+	 * const event_target = new TypedEventTarget<
+	 *     { myEvent: CustomEvent<{ myValue: number }> }
+	 * >();
+	 *
+	 * const event = new CustomEvent('myEvent', { detail: { myValue: 1 } });
+	 *
+	 * event_target.addEventListener('myEvent', console.log);
+	 *
+	 * event_target.dispatchEvent(event); // `{ myValue: 1 }`
+	 * ```
+	 */
+	dispatchEvent<Event extends EventRecord[keyof EventRecord]>(
 		event: Event,
 	): boolean {
 		return super.dispatchEvent(event);
 	}
 
-	removeEventListener<Type extends keyof EventMap>(
+	/**
+	 * Removes the event listener in target's event listener list with the same type,
+	 * callback, and options.
+	 *
+	 * @param type
+	 * @param listener
+	 * @param options
+	 *
+	 * @example
+	 * ```typescript
+	 * import { TypedEventTarget } from 'https://deno.land/x/enzastdlib/events/mod.ts';
+	 *
+	 * type MyEvents = {
+	 *     myEvent: CustomEvent<{ myValue: number }>;
+	 * };
+	 *
+	 * function onMyEvent(event: MyEvents['myEvent']): void {
+	 *     console.log(event.detail.myValue);
+	 * }
+	 *
+	 * const event_target = new TypedEventTarget<MyEvents>();
+	 *
+	 * event_target.addEventListener('myEvent', onMyEvent);
+	 * event_target.removeEventListener('myEvent', onMyEvent);
+	 * ```
+	 */
+	removeEventListener<Type extends keyof EventRecord>(
 		type: Type,
-		listener: TypedEventListener<EventMap[Type]> | null,
+		listener: TypedEventListener<EventRecord[Type]> | null,
 		options?: boolean | EventListenerOptions | undefined,
 	): void {
 		super.removeEventListener(

--- a/json5/README.md
+++ b/json5/README.md
@@ -4,11 +4,13 @@ Parse JSON5 documents and expressions.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/json5/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/json5/mod.ts?doc).
 
 ## Dependencies
 

--- a/json5/TODO.md
+++ b/json5/TODO.md
@@ -1,5 +1,4 @@
 # TODO
 
-- Add docstrings.
-
+- Add tests for `parseJSON5ExpressionRecord`.
 - Vendor dependencies into single file importable scripts.

--- a/json5/document.ts
+++ b/json5/document.ts
@@ -1,5 +1,42 @@
 import { parse, stringify } from '../vendor/@CesiumLabs-json5.ts';
 
+/**
+ * Parses a JSON5 document into a JavaScript value.
+ *
+ * @param text
+ * @param reviver
+ * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { parseJSON5 } from 'https://deno.land/x/enzastdlib/json5/mod.ts';
+ *
+ * assertEquals(
+ *     parseJSON5(`{propA:'Hello',propB:'World!'}`),
+ *     { propA: 'Hello', propB: 'World!' }
+ * );
+ * ```
+ */
 export const parseJSON5 = parse;
 
+/**
+ * Returns a JavaScript value stringified into a JSON5 document.
+ *
+ * @param value
+ * @param replacer
+ * @param space
+ * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { stringifyJSON5 } from 'https://deno.land/x/enzastdlib/json5/mod.ts';
+ *
+ * assertEquals(
+ *     stringifyJSON5({ propA: 'Hello', propB: 'World!' }),
+ *     `{propA:'Hello',propB:'World!'}`
+ * );
+ * ```
+ */
 export const stringifyJSON5 = stringify;

--- a/json5/expression.ts
+++ b/json5/expression.ts
@@ -25,7 +25,7 @@ import { JSON5_TYPE_NAMES } from './types.ts';
  * import {
  *     JSON5_TYPE_NAMES,
  *     parseJSON5Expression,
- * } from 'https://deno.land/x/enzastdlib/expression/mod.ts';
+ * } from 'https://deno.land/x/enzastdlib/json5/mod.ts';
  *
  * assertEquals(
  *     parseJSON5Expression(JSON5_TYPE_NAMES.array, `'Hello', 'World!'`),

--- a/json5/expression.ts
+++ b/json5/expression.ts
@@ -8,6 +8,56 @@ import type {
 } from './types.ts';
 import { JSON5_TYPE_NAMES } from './types.ts';
 
+/**
+ * Returns an expression parsed following a simplified JSON5 syntax.
+ *
+ * > **NOTE**: If your specified type has start / end delimiters those are not required.
+ * >
+ * > ex. For objects use `propA: 'Hello', propB: 'World!'` instead of `{ propA: 'Hello', propB: 'World!' }`
+ *
+ * @param type
+ * @param expression
+ * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import {
+ *     JSON5_TYPE_NAMES,
+ *     parseJSON5Expression,
+ * } from 'https://deno.land/x/enzastdlib/expression/mod.ts';
+ *
+ * assertEquals(
+ *     parseJSON5Expression(JSON5_TYPE_NAMES.array, `'Hello', 'World!'`),
+ *     ['Hello', 'World!']
+ * );
+ *
+ * assertEquals(
+ *     parseJSON5Expression(JSON5_TYPE_NAMES.boolean, 'true'),
+ *     true
+ * );
+ *
+ * assertEquals(
+ *     parseJSON5Expression(JSON5_TYPE_NAMES.null, 'null'),
+ *     null
+ * );
+ *
+ * assertEquals(
+ *     parseJSON5Expression(JSON5_TYPE_NAMES.number, '42'),
+ *     42
+ * );
+ *
+ * assertEquals(
+ *     parseJSON5Expression(JSON5_TYPE_NAMES.object, `propA: 'Hello', propB: 'World!'`),
+ *     { propA: 'Hello', propB: 'World!' }
+ * );
+ *
+ * assertEquals(
+ *     parseJSON5Expression(JSON5_TYPE_NAMES.string, 'Hello World!'),
+ *     'Hello World!'
+ * );
+ * ```
+ */
 export function parseJSON5Expression(
 	type: (typeof JSON5_TYPE_NAMES)['array'],
 	expression: string,

--- a/json5/record.ts
+++ b/json5/record.ts
@@ -2,8 +2,72 @@ import { parseJSON5Expression } from './expression.ts';
 
 import type { JSONSchema, JSONSchemaObject } from '../schema/mod.ts';
 
+/**
+ * Represents a record of JSON5 expressions.
+ *
+ * @example
+ * ```typescript
+ * import type { JSON5ExpressionRecord } from 'https://deno.land/x/enzastdlib/json5/mod.ts';
+ *
+ * const record = {
+ *     myArray: `'Hello', 'World!'`,
+ * } satisfies JSON5ExpressionRecord;
+ * ```
+ */
 export type JSON5ExpressionRecord = Record<string, string | undefined>;
 
+/**
+ * Returns an expression parsed following a simplified JSON5 syntax using a
+ * a JSON Schema for type hinting.
+ *
+ * > **WARNING**: Only top-level keys are used for type hinting during parsing.
+ *
+ * @param schema
+ * @param record
+ * @returns
+ *
+ * @exanoke
+ * **schema.ts**
+ * ```typescript
+ * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * export const MY_SCHEMA = {
+ *     type: 'object',
+ *
+ *     required: ['_'],
+ *     additionalProperties: false,
+ *
+ *     properties: {
+ *         myArray: {
+ *             type: 'array',
+ *
+ *             items: {
+ *                 type: 'string',
+ *             },
+ *         },
+ *     },
+ * } as const satisfies JSONSchema;
+ *
+ * export type MySchemaType = typeofschema<typeof MY_SCHEMA>;
+ * ```
+ *
+ * **mod.ts**
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { parseJSON5ExpressionRecord } from 'https://deno.land/x/enzastdlib/json5/mod.ts';
+ *
+ * import type { MySchemaType } from "./schema.ts";
+ * import { MY_SCHEMA } from "./schema.ts";
+ *
+ * const parsed = parseJSON5ExpressionRecord<MySchemaType>(MY_SCHEMA, {
+ *     myArray: `'Hello', 'World!'`,
+ * });
+ *
+ * assertEquals(parsed, {
+ *     myArray: ['Hello', 'World!'],
+ * });
+ * ```
+ */
 export function parseJSON5ExpressionRecord<Type>(
 	schema: JSONSchemaObject,
 	record: JSON5ExpressionRecord,

--- a/json5/record.ts
+++ b/json5/record.ts
@@ -26,7 +26,7 @@ export type JSON5ExpressionRecord = Record<string, string | undefined>;
  * @param record
  * @returns
  *
- * @exanoke
+ * @example
  * **schema.ts**
  * ```typescript
  * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';

--- a/os/README.md
+++ b/os/README.md
@@ -4,11 +4,13 @@ Utilities for abstracting away operating system specifics.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/os/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/os/mod.ts?doc).
 
 ## Compatibility
 

--- a/os/README.md
+++ b/os/README.md
@@ -27,3 +27,7 @@ The following functions are compatible with Deno only:
 This module imports the following external libraries:
 
 - https://github.com/denoland/deno_std/tree/main/path
+
+## Credits
+
+- https://github.com/adrg/xdg — Had concise documentation for polyfilling the XDG Base Directory spec on non-XDG platforms.

--- a/os/darwin.ts
+++ b/os/darwin.ts
@@ -2,28 +2,93 @@ import { join } from '../vendor/@deno-std-path.ts';
 
 /**
  * Returns the home directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `$HOME`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserHome } from 'https://deno.land/x/enzastdlib/os/darwin.ts';
+ *
+ * assertEquals(
+ *     getUserHome(),
+ *     '/Users/novacbn'
+ * );
+ * ```
  */
 export const getUserHome = () => Deno.env.get('HOME')!;
 
 /**
  * Returns the cached data directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `$HOME` joined with `Library/Caches`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserCache } from 'https://deno.land/x/enzastdlib/os/darwin.ts';
+ *
+ * assertEquals(
+ *     getUserCache(),
+ *     '/Users/novacbn/Library/Caches'
+ * );
+ * ```
  */
 export const getUserCache = () => join(getUserHome(), 'Library', 'Caches');
 
 /**
  * Returns the config directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `$HOME` joined with `Library/Application Support`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserConfig } from 'https://deno.land/x/enzastdlib/os/darwin.ts';
+ *
+ * assertEquals(
+ *     getUserConfig(),
+ *     '/Users/novacbn/Library/Application Support'
+ * );
+ * ```
  */
 export const getUserConfig = () =>
 	join(getUserHome(), 'Library', 'Application Support');
 
 /**
  * Returns the data directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `$HOME` joined with `Library/Application Support`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserData } from 'https://deno.land/x/enzastdlib/os/darwin.ts';
+ *
+ * assertEquals(
+ *     getUserData(),
+ *     '/Users/novacbn/Library/Application Support'
+ * );
+ * ```
  */
 export const getUserData = () =>
 	join(getUserHome(), 'Library', 'Application Support');
 
 /**
  * Returns the state directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `$HOME` joined with `Library/Application Support`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserState } from 'https://deno.land/x/enzastdlib/os/darwin.ts';
+ *
+ * assertEquals(
+ *     getUserState(),
+ *     '/Users/novacbn/Library/Application Support'
+ * );
+ * ```
  */
 export const getUserState = () =>
 	join(getUserHome(), 'Library', 'Application Support');

--- a/os/linux.ts
+++ b/os/linux.ts
@@ -14,6 +14,7 @@ import { join } from '../vendor/@deno-std-path.ts';
  *     getUserHome(),
  *     '/home/novacbn'
  * );
+ * ```
  */
 export const getUserHome = () => Deno.env.get('HOME')!;
 
@@ -32,6 +33,7 @@ export const getUserHome = () => Deno.env.get('HOME')!;
  *     getUserCache(),
  *     '/home/novacbn/.cache'
  * );
+ * ```
  */
 export const getUserCache = () =>
 	Deno.env.get('XDG_CACHE_HOME') ??
@@ -52,6 +54,7 @@ export const getUserCache = () =>
  *     getUserConfig(),
  *     '/home/novacbn/.config'
  * );
+ * ```
  */
 export const getUserConfig = () =>
 	Deno.env.get('XDG_CONFIG_HOME') ??
@@ -72,6 +75,7 @@ export const getUserConfig = () =>
  *     getUserData(),
  *     '/home/novacbn/.local/share'
  * );
+ * ```
  */
 export const getUserData = () =>
 	Deno.env.get('XDG_DATA_HOME') ??
@@ -92,6 +96,7 @@ export const getUserData = () =>
  *     getUserState(),
  *     '/home/novacbn/.local/state'
  * );
+ * ```
  */
 export const getUserState = () =>
 	Deno.env.get('XDG_STATE_HOME') ??

--- a/os/linux.ts
+++ b/os/linux.ts
@@ -2,11 +2,36 @@ import { join } from '../vendor/@deno-std-path.ts';
 
 /**
  * Returns the home directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `$HOME`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserHome } from 'https://deno.land/x/enzastdlib/os/linux.ts';
+ *
+ * assertEquals(
+ *     getUserHome(),
+ *     '/home/novacbn'
+ * );
  */
 export const getUserHome = () => Deno.env.get('HOME')!;
 
 /**
  * Returns the cached data directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `XDG_CACHE_HOME` or `$HOME`
+ * > joined with `.cache` as a fallback.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserCache } from 'https://deno.land/x/enzastdlib/os/linux.ts';
+ *
+ * assertEquals(
+ *     getUserCache(),
+ *     '/home/novacbn/.cache'
+ * );
  */
 export const getUserCache = () =>
 	Deno.env.get('XDG_CACHE_HOME') ??
@@ -14,6 +39,19 @@ export const getUserCache = () =>
 
 /**
  * Returns the config directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `XDG_CONFIG_HOME` or `$HOME`
+ * > joined with `.config` as a fallback.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserConfig } from 'https://deno.land/x/enzastdlib/os/linux.ts';
+ *
+ * assertEquals(
+ *     getUserConfig(),
+ *     '/home/novacbn/.config'
+ * );
  */
 export const getUserConfig = () =>
 	Deno.env.get('XDG_CONFIG_HOME') ??
@@ -21,6 +59,19 @@ export const getUserConfig = () =>
 
 /**
  * Returns the data directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `XDG_DATA_HOME` or `$HOME`
+ * > joined with `.local/share` as a fallback.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserData } from 'https://deno.land/x/enzastdlib/os/linux.ts';
+ *
+ * assertEquals(
+ *     getUserData(),
+ *     '/home/novacbn/.local/share'
+ * );
  */
 export const getUserData = () =>
 	Deno.env.get('XDG_DATA_HOME') ??
@@ -28,6 +79,19 @@ export const getUserData = () =>
 
 /**
  * Returns the state directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `XDG_STATE_HOME` or `$HOME`
+ * > joined with `.local/state` as a fallback.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserState } from 'https://deno.land/x/enzastdlib/os/linux.ts';
+ *
+ * assertEquals(
+ *     getUserState(),
+ *     '/home/novacbn/.local/state'
+ * );
  */
 export const getUserState = () =>
 	Deno.env.get('XDG_STATE_HOME') ??

--- a/os/mod.ts
+++ b/os/mod.ts
@@ -1,6 +1,9 @@
 /**
  * Utilities for abstracting away operating system specifics.
  *
+ * > **NOTE**: You can import individual platforms via `import { ... } from 'https://deno.land/x/enzastdlib/os/${PLATFORM}.ts';`
+ * > or have the platform be auto-detected via `import { ... } from 'https://deno.land/x/enzastdlib/os/mod.ts';`.
+ *
  * @module
  */
 

--- a/os/windows.ts
+++ b/os/windows.ts
@@ -1,24 +1,84 @@
 /**
  * Returns the cached data directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `%LocalAppData%`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserCache } from 'https://deno.land/x/enzastdlib/os/windows.ts';
+ *
+ * assertEquals(
+ *     getUserCache(),
+ *     'C:\\Users\\novacbn\\AppData\\Local'
+ * );
  */
 export const getUserCache = () => Deno.env.get('LocalAppData')!;
 
 /**
  * Returns the config directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `%AppData%`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserConfig } from 'https://deno.land/x/enzastdlib/os/windows.ts';
+ *
+ * assertEquals(
+ *     getUserConfig(),
+ *     'C:\\Users\\novacbn\\AppData\\Roaming'
+ * );
  */
 export const getUserConfig = () => Deno.env.get('AppData')!;
 
 /**
  * Returns the data directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `%LocalAppData%`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserData } from 'https://deno.land/x/enzastdlib/os/windows.ts';
+ *
+ * assertEquals(
+ *     getUserData(),
+ *     'C:\\Users\\novacbn\\AppData\\Local'
+ * );
  */
 export const getUserData = () => Deno.env.get('LocalAppData')!;
 
 /**
  * Returns the home directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `%USERPROFILE%`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserHome } from 'https://deno.land/x/enzastdlib/os/windows.ts';
+ *
+ * assertEquals(
+ *     getUserHome(),
+ *     'C:\\Users\\novacbn'
+ * );
  */
 export const getUserHome = () => Deno.env.get('USERPROFILE')!;
 
 /**
  * Returns the state directory of the current user.
+ *
+ * > **NOTE**: Returns the value of the environment variable `%LocalAppData%`.
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { getUserState } from 'https://deno.land/x/enzastdlib/os/windows.ts';
+ *
+ * assertEquals(
+ *     getUserState(),
+ *     'C:\\Users\\novacbn\\AppData\\Local'
+ * );
  */
 export const getUserState = () => Deno.env.get('LocalAppData')!;

--- a/os/windows.ts
+++ b/os/windows.ts
@@ -12,6 +12,7 @@
  *     getUserCache(),
  *     'C:\\Users\\novacbn\\AppData\\Local'
  * );
+ * ```
  */
 export const getUserCache = () => Deno.env.get('LocalAppData')!;
 
@@ -29,6 +30,7 @@ export const getUserCache = () => Deno.env.get('LocalAppData')!;
  *     getUserConfig(),
  *     'C:\\Users\\novacbn\\AppData\\Roaming'
  * );
+ * ```
  */
 export const getUserConfig = () => Deno.env.get('AppData')!;
 
@@ -46,6 +48,7 @@ export const getUserConfig = () => Deno.env.get('AppData')!;
  *     getUserData(),
  *     'C:\\Users\\novacbn\\AppData\\Local'
  * );
+ * ```
  */
 export const getUserData = () => Deno.env.get('LocalAppData')!;
 
@@ -63,6 +66,7 @@ export const getUserData = () => Deno.env.get('LocalAppData')!;
  *     getUserHome(),
  *     'C:\\Users\\novacbn'
  * );
+ * ```
  */
 export const getUserHome = () => Deno.env.get('USERPROFILE')!;
 
@@ -80,5 +84,6 @@ export const getUserHome = () => Deno.env.get('USERPROFILE')!;
  *     getUserState(),
  *     'C:\\Users\\novacbn\\AppData\\Local'
  * );
+ * ```
  */
 export const getUserState = () => Deno.env.get('LocalAppData')!;

--- a/path/README.md
+++ b/path/README.md
@@ -4,8 +4,10 @@ Utilities for working with file system paths and URLs.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/path/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/path/mod.ts?doc).

--- a/path/issubpath.ts
+++ b/path/issubpath.ts
@@ -6,6 +6,17 @@ import { relative } from '../vendor/@deno-std-path.ts';
  * @param parent
  * @param child
  * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { isSubPath } from 'https://deno.land/x/enzastdlib/path/mod.ts';
+ *
+ * assertEquals(
+ *     isSubPath('/home/novacbn', '/home/novacbn/Pictures'),
+ *     true
+ * );
+ * ```
  */
 export function isSubPath(parent: string, child: string): boolean {
 	const relative_path = relative(parent, child);

--- a/path/issuburl.ts
+++ b/path/issuburl.ts
@@ -6,6 +6,20 @@ import { relativePathname } from './relativepathname.ts';
  * @param parent
  * @param child
  * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { isSubURL } from 'https://deno.land/x/enzastdlib/path/mod.ts';
+ *
+ * const URL_A = new URL("https://example.domain/assets");
+ * const URL_B = new URL("https://example.domain/assets/scripts/main.js");
+ *
+ * assertEquals(
+ *     isSubURL(URL_A, URL_B),
+ *     true
+ * );
+ * ```
  */
 export function isSubURL(parent: URL, child: URL): boolean {
 	if (parent.origin !== child.origin) return false;

--- a/path/relativepathname.ts
+++ b/path/relativepathname.ts
@@ -8,6 +8,20 @@ const { relative } = posix;
  * @param from
  * @param to
  * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { relativePathname } from 'https://deno.land/x/enzastdlib/path/mod.ts';
+ *
+ * const URL_A = new URL("https://example.domain/assets");
+ * const URL_B = new URL("https://example.domain/assets/scripts/main.js");
+ *
+ * assertEquals(
+ *     relativePathname(URL_A, URL_B),
+ *     'scripts/main.js'
+ * );
+ * ```
  */
 export function relativePathname(from: URL, to: URL): string {
 	return relative(from.pathname, to.pathname);

--- a/realm/README.md
+++ b/realm/README.md
@@ -11,11 +11,13 @@ Create custom JavaScript and TypeScript execution environments.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/realm/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/realm/mod.ts?doc).
 
 ## Compatibility
 

--- a/realm/evaluate.ts
+++ b/realm/evaluate.ts
@@ -9,7 +9,7 @@ export interface EvaluateModuleOptions<GlobalThisType = unknown> {
 	/**
 	 * Represents the `globalThis` global object exposed to the execution environment.
 	 *
-	 * **NOTE**: All members of this object will be exposed as globals to the evaluated
+	 * > **NOTE**: All members of this object will be exposed as globals to the evaluated
 	 * code.
 	 */
 	readonly globalThis?: GlobalThisType;

--- a/realm/mod.ts
+++ b/realm/mod.ts
@@ -10,9 +10,9 @@
  *
  * This module imports the following external libraries:
  *
+ * - https://github.com/denoland/deno_emit
  * - https://github.com/denoland/deno_std/tree/main/fs
  * - https://github.com/denoland/deno_std/tree/main/path
- * - https://github.com/esbuild/deno-esbuild
  *
  * @module
  */

--- a/rpc-http/README.md
+++ b/rpc-http/README.md
@@ -8,11 +8,13 @@ Create fully typed and validated RPC clients and servers using HTTP as the trans
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/rpc-http/mod.ts';
+```
 
-## Description
+## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/rpc-http/mod.ts?doc).
 
 ## Compatibility
 

--- a/rpc-messageport/README.md
+++ b/rpc-messageport/README.md
@@ -4,8 +4,10 @@ Create fully typed and validated RPC clients and servers using [`MessagePort`](h
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/rpc-messageport/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/rpc-messageport/mod.ts?doc).

--- a/rpc-protocol/README.md
+++ b/rpc-protocol/README.md
@@ -10,11 +10,13 @@ Create fully typed and validated RPC clients and servers powered by [JSON Schema
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/rpc-protocol/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/rpc-protocol/mod.ts?doc).
 
 ## Dependencies
 

--- a/rpc-protocol/payload.ts
+++ b/rpc-protocol/payload.ts
@@ -42,8 +42,8 @@ export interface CallOptions {
 	 * Represents a signal that allows you to abort an ongoing call to the
 	 * server.
 	 *
-	 * **NOTE**: The client transport layer has to implement support for
-	 * this feature. ex. whatever implements `ClientOptions.processProcedure`.
+	 * > **NOTE**: The client transport layer has to implement support for
+	 * > this feature. ex. whatever implements `ClientOptions.processProcedure`.
 	 */
 	readonly signal?: AbortSignal;
 }

--- a/rpc-streams/README.md
+++ b/rpc-streams/README.md
@@ -4,11 +4,13 @@ Create fully typed and validated RPC clients and servers using a pair of [`Reada
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/rpc-streams/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/rpc-streams/mod.ts?doc).
 
 ## Dependencies
 

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -4,8 +4,10 @@ Contains supplemental typing for creating fully typed and validated RPC clients 
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/rpc/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/rpc/mod.ts?doc).

--- a/schema/README.md
+++ b/schema/README.md
@@ -4,11 +4,13 @@ Create easy to use validators powered by [JSON Schema 2019-09](https://json-sche
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/schema/mod.ts?doc).
 
 ## Dependencies
 

--- a/schema/errors.ts
+++ b/schema/errors.ts
@@ -1,5 +1,14 @@
+/**
+ * Represents details about a validation error that occured.
+ */
 export interface Error {
+	/**
+	 * Represents the details about what validation error occured.
+	 */
 	message: string;
 
+	/**
+	 * Represents the name of the property where the validation error occured.
+	 */
 	property: string;
 }

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -5,18 +5,116 @@ import type {
 	TypeName,
 } from '../vendor/@jrylan-json-schema-typed.ts';
 
+/**
+ * Represents the JSON Schema structure typing for arrays.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaArray } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_ARRAY_SCHEMA = {
+ *     type: 'array',
+ *
+ *     items: {
+ *         type: 'string',
+ *     },
+ * } as const satisfies JSONSchemaArray;
+ * ```
+ */
 export type JSONSchemaArray = JSONSchema201909.Array;
 
+/**
+ * Represents the JSON Schema structure typing for booleans.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaBoolean } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_BOOLEAN_SCHEMA = {
+ *     type: 'boolean',
+ * } as const satisfies JSONSchemaBoolean;
+ * ```
+ */
 export type JSONSchemaBoolean = JSONSchema201909.Boolean;
 
+/**
+ * Represents the JSON Schema structure typing for nulls.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaNull } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_NULL_SCHEMA = {
+ *     type: 'null',
+ * } as const satisfies JSONSchemaNull;
+ * ```
+ */
 export type JSONSchemaNull = JSONSchema201909.Null;
 
+/**
+ * Represents the JSON Schema structure typing for numbers.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaNumber } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_NUMBER_SCHEMA = {
+ *     type: 'number',
+ *
+ *     minimum: 0,
+ *     maximum: 42,
+ * } as const satisfies JSONSchemaNumber;
+ * ```
+ */
 export type JSONSchemaNumber = JSONSchema201909.Number;
 
+/**
+ * Represents the JSON Schema structure typing for objects.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaObject } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_OBJECT_SCHEMA = {
+ *     type: 'object',
+ *
+ *     additionalProperties: {
+ *         type: 'string',
+ *     },
+ * } as const satisfies JSONSchemaObject;
+ * ```
+ */
 export type JSONSchemaObject = JSONSchema201909.Object;
 
+/**
+ * Represents the JSON Schema structure typing for strings.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaString } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_STRING_SCHEMA = {
+ *     type: 'string',
+ *
+ *     minLength: 1,
+ *     maxLength: 64,
+ * } as const satisfies JSONSchemaString;
+ * ```
+ */
 export type JSONSchemaString = JSONSchema201909.String;
 
+/**
+ * Represents a union of all supported JSON Schema structure typings.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_STRING_SCHEMA = {
+ *     type: 'string',
+ * } as const satisfies JSONSchema;
+ * ```
+ */
 export type JSONSchema =
 	| JSONSchemaArray
 	| JSONSchemaBoolean
@@ -25,8 +123,45 @@ export type JSONSchema =
 	| JSONSchemaObject
 	| JSONSchemaString;
 
+/**
+ * Represents a union of all possible type names supported by JSON Schema.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchemaTypes } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const my_schema_type = 'integer' satisfies JSONSchemaTypes;
+ * ```
+ */
 export type JSONSchemaTypes = `${TypeName}`;
 
+/**
+ * Converts a constant JSON Schema object into TypeScript typing at compile-time.
+ *
+ * > **WARNING**: Depending on the complexity of your JSON Schemas, your type checking
+ * > and continous integration suites might experience slowdowns.
+ *
+ * > **WARNING**: It is recommended to put schema-related code into a seperate
+ * > TypeScript file (ex. `*.schema.ts`) to allow your IDE to cache the resulting
+ * > typings.
+ * >
+ * > Otherwise you might experience slowdowns with your IDE.
+ *
+ * @example
+ * ```typescript
+ * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_OBJECT_SCHEMA = {
+ *     type: 'object',
+ *
+ *     additionalProperties: {
+ *         type: 'string',
+ *     },
+ * } as const satisfies JSONSchema;
+ *
+ * type MyObjectType = typeofschema<typeof MY_OBJECT_SCHEMA>; // `{ [x: string]: string; }`
+ * ```
+ */
 export type typeofschema<Schema extends JSONSchema> = FromSchema<
 	// @ts-ignore - HACK: They're both draft 2019-09 based, they just have mismatched types.
 	Schema

--- a/schema/types.ts
+++ b/schema/types.ts
@@ -2,6 +2,18 @@ import type { JsonValue } from '../vendor/@deno-std-json.ts';
 
 import type { JSONSchemaTypes } from './schema.ts';
 
+/**
+ * Returns the JSON Schema type of a specified JavaScript type.
+ *
+ * @example
+ * ```typescript
+ * import type { SchemaTypeOf } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const my_string = 'Hello World!';
+ *
+ * type MyStringSchemaType = SchemaTypeOf<typeof my_string>; // "string"
+ * ```
+ */
 export type SchemaTypeOf<Type extends JsonValue> = Type extends boolean
 	? 'boolean'
 	: (Type extends null ? 'null' : (
@@ -15,6 +27,18 @@ export type SchemaTypeOf<Type extends JsonValue> = Type extends boolean
 		)
 	));
 
+/**
+ * Returns the JavaScript type of the specified JSON Schema type.
+ *
+ * @example
+ * ```typescript
+ * import type { TypeOfSchemaType } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * type MySchemaType = 'integer';
+ *
+ * type MyType = TypeOfSchemaType<MySchemaType>; // `number`
+ * ```
+ */
 export type TypeOfSchemaType<SchemaType extends JSONSchemaTypes> =
 	SchemaType extends 'boolean' ? boolean
 		: (SchemaType extends 'null' ? null : (

--- a/schema/util.ts
+++ b/schema/util.ts
@@ -1,1 +1,4 @@
+/**
+ * Represents the JSON Schema version supported by this module.
+ */
 export const VERSION_SCHEMA = '2019-09';

--- a/schema/validator.ts
+++ b/schema/validator.ts
@@ -6,14 +6,190 @@ import type { Error } from './errors.ts';
 import type { JSONSchema } from './schema.ts';
 import { VERSION_SCHEMA } from './util.ts';
 
+/**
+ * Represents a JSON Schema validator made by `makeValidator`.
+ */
 export interface Validator<Type = unknown> {
+	/**
+	 * Returns `true` if the specified `value` has no validation errors, otherwise
+	 * `false`.
+	 *
+	 * @param value
+	 * @returns
+	 *
+	 * @example
+	 * **schema.ts**
+	 * ```
+	 * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+	 *
+	 * const MY_STRING_SCHEMA = {
+	 *     type: 'string',
+	 *
+	 *     minLength: 1,
+	 * } as const satisfies JSONSchema;
+	 *
+	 * type MyStringType = typeofschema<typeof MY_STRING_SCHEMA>;
+	 * ```
+	 *
+	 * **mod.ts**
+	 * ```typescript
+	 * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+	 * import { makeValidator } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+	 *
+	 * import type { MyStringType } from './schema.ts';
+	 * import { MY_STRING_SCHEMA } from './schema.ts';
+	 *
+	 * const validator = makeValidator<MyStringType>(MY_STRING_SCHEMA);
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf('Hello World!'),
+	 *     true,
+	 * );
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf(''),
+	 *     false,
+	 * );
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf(42),
+	 *     false,
+	 * );
+	 * ```
+	 */
 	instanceOf(value: Type | unknown): value is Type;
 
+	/**
+	 * Returns `Error` objects of any validation errors that have occured regarding
+	 * the specified `value`, if any.
+	 *
+	 * @param value
+	 * @returns
+	 *
+	 * @example
+	 * **schema.ts**
+	 * ```
+	 * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+	 *
+	 * const MY_STRING_SCHEMA = {
+	 *     type: 'string',
+	 *
+	 *     minLength: 1,
+	 * } as const satisfies JSONSchema;
+	 *
+	 * type MyStringType = typeofschema<typeof MY_STRING_SCHEMA>;
+	 * ```
+	 *
+	 * **mod.ts**
+	 * ```typescript
+	 * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+	 * import { makeValidator } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+	 *
+	 * import type { MyStringType } from './schema.ts';
+	 * import { MY_STRING_SCHEMA } from './schema.ts';
+	 *
+	 * const validator = makeValidator<MyStringType>(MY_STRING_SCHEMA);
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf('Hello World!'),
+	 *     undefined,
+	 * );
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf(''),
+	 *     [{ message: "String is too short (0 < 1).", property: "#" }],
+	 * );
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf(42),
+	 *     [{ message: 'Instance type "number" is invalid. Expected "string".', property: "#" }],
+	 * );
+	 * ```
+	 */
 	test(value: Type | unknown): Error[] | undefined;
 
+	/**
+	 * Throws an exception if any validation errors occured regarding the specified `value`,
+	 * otherwise returns `true`.
+	 *
+	 * @param value
+	 * @returns
+	 *
+	 * @example
+	 * **schema.ts**
+	 * ```
+	 * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+	 *
+	 * const MY_STRING_SCHEMA = {
+	 *     type: 'string',
+	 *
+	 *     minLength: 1,
+	 * } as const satisfies JSONSchema;
+	 *
+	 * type MyStringType = typeofschema<typeof MY_STRING_SCHEMA>;
+	 * ```
+	 *
+	 * **mod.ts**
+	 * ```typescript
+	 * import { assertEquals, assertThrows } from 'https://deno.land/std/testing/asserts.ts';
+	 * import { ValidationError } from 'https://deno.land/x/enzastdlib/errors/mod.ts';
+	 * import { makeValidator } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+	 *
+	 * import type { MyStringType } from './schema.ts';
+	 * import { MY_STRING_SCHEMA } from './schema.ts';
+	 *
+	 * const validator = makeValidator<MyStringType>(MY_STRING_SCHEMA);
+	 *
+	 * assertEquals(
+	 *     validator.instanceOf('Hello World!'),
+	 *     true,
+	 * )
+	 *
+	 * assertThrows(
+	 *     () => validator.instanceOf(''),
+	 *     ValidationError,
+	 * );
+	 *
+	 * assertThrows(
+	 *     () => validator.instanceOf(42),
+	 *     ValidationError,
+	 * );
+	 * ```
+	 */
 	validate(value: Type | unknown): value is Type;
 }
 
+/**
+ * Makes a new `Validator` for validating input values are of the specified `schema`
+ * JSON Schema definition.
+ *
+ * @param schema
+ * @returns
+ *
+ * @example
+ * **schema.ts**
+ * ```
+ * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * const MY_STRING_SCHEMA = {
+ *     type: 'string',
+ *
+ *     minLength: 1,
+ * } as const satisfies JSONSchema;
+ *
+ * type MyStringType = typeofschema<typeof MY_STRING_SCHEMA>;
+ * ```
+ *
+ * **mod.ts**
+ * ```typescript
+ * import { makeValidator } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
+ *
+ * import type { MyStringType } from './schema.ts';
+ * import { MY_STRING_SCHEMA } from './schema.ts';
+ *
+ * const validator = makeValidator<MyStringType>(MY_STRING_SCHEMA);
+ * ```
+ */
 export function makeValidator<Type>(
 	schema: JSONSchema,
 ): Validator<Type> {

--- a/schema/validator.ts
+++ b/schema/validator.ts
@@ -19,7 +19,7 @@ export interface Validator<Type = unknown> {
 	 *
 	 * @example
 	 * **schema.ts**
-	 * ```
+	 * ```typescript
 	 * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
 	 *
 	 * const MY_STRING_SCHEMA = {
@@ -68,7 +68,7 @@ export interface Validator<Type = unknown> {
 	 *
 	 * @example
 	 * **schema.ts**
-	 * ```
+	 * ```typescript
 	 * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
 	 *
 	 * const MY_STRING_SCHEMA = {
@@ -117,7 +117,7 @@ export interface Validator<Type = unknown> {
 	 *
 	 * @example
 	 * **schema.ts**
-	 * ```
+	 * ```typescript
 	 * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
 	 *
 	 * const MY_STRING_SCHEMA = {
@@ -168,7 +168,7 @@ export interface Validator<Type = unknown> {
  *
  * @example
  * **schema.ts**
- * ```
+ * ```typescript
  * import type { JSONSchema, typeofschema } from 'https://deno.land/x/enzastdlib/schema/mod.ts';
  *
  * const MY_STRING_SCHEMA = {

--- a/strings/README.md
+++ b/strings/README.md
@@ -4,8 +4,10 @@ Utilities for working with strings.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/strings/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/strings/mod.ts?doc).

--- a/strings/splitlength.ts
+++ b/strings/splitlength.ts
@@ -11,6 +11,27 @@ const EXPRESSION_WORDS = /\s*[^\s]+/g;
  * @param text
  * @param max_length
  * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+ * import { splitLength } from 'https://deno.land/x/enzastdlib/strings/mod.ts';
+ *
+ * // **NOTE**: Taken from `deno lint --help`.
+ * const text =
+ *     'The configuration file can be used to configure different aspects of deno including TypeScript, linting, and code formatting. Typically the configuration file will be called `deno.json` or `deno.jsonc` and automatically detected; in that case this flag is not necessary.\nSee https://deno.land/manual@v1.33.0/getting_started/configuration_file';
+ *
+ * assertEquals(
+ *     splitLength(text, 66),
+ *     [
+ *         'The configuration file can be used to configure different aspects of',
+ *         'deno including TypeScript, linting, and code formatting. Typically',
+ *         'the configuration file will be called `deno.json` or `deno.jsonc` and',
+ *         'automatically detected; in that case this flag is not necessary.',
+ *         'See https://deno.land/manual@v1.33.0/getting_started/configuration_file',
+ *     ];
+ * );
+ * ```
  */
 export function splitLength(text: string, max_length: number): string[] {
 	const lines = text.split(EXPRESSION_NEWLINE);

--- a/testing/README.md
+++ b/testing/README.md
@@ -4,8 +4,10 @@ Utilities for working with Deno's testing API.
 
 ## Importing
 
-...
+```typescript
+import * as mod from 'https://deno.land/x/enzastdlib/testing/mod.ts';
+```
 
 ## Documentation
 
-...
+Visit the documentation at [Deno's module registry](https://deno.land/x/enzastdlib/testing/mod.ts?doc).

--- a/testing/asserts.ts
+++ b/testing/asserts.ts
@@ -19,6 +19,18 @@ type BuiltinTypes =
 /**
  * Make an assertion that `actual` has the type of `expected_type`.
  * If not then throw.
+ *
+ * @param actual
+ * @param expected_type
+ * @param message
+ * @returns
+ *
+ * @example
+ * ```typescript
+ * import { assertTypeOf } from 'https://deno.land/x/enzastdlib/testing/mod.ts';
+ *
+ * assertTypeOf('Hello World!', 'string');
+ * ```
  */
 export function assertTypeOf(
 	actual: unknown,


### PR DESCRIPTION
# CHANGELOG

- Added import examples to repository files.
- Added Deno module repository documentation links.
- [@enzastdlib/async] Added missing docstrings and examples.
- [@enzastdlib/collections] Added missing docstrings and examples.
- [@enzastdlib/errors] Added missing docstrings and examples.
- [@enzastdlib/events] Added missing docstrings and examples.
- [@enzastdlib/json5] Added missing docstrings and examples. 
- [@enzastdlib/os] Added missing docstrings and examples. 
- [@enzastdlib/path] Added missing docstrings and examples. 
- [@enzastdlib/strings] Added missing docstrings and examples.
- [@enzastdlib/schema] Added missing docstrings and examples. 
- [@enzastdlib/testing] Added missing docstrings and examples. 