### PR TITLE
Seperate HTTP RPC Call Types into Different Pathnames

### DIFF
--- a/rpc-http/client.ts
+++ b/rpc-http/client.ts
@@ -9,7 +9,7 @@ import type {
 } from '../rpc-protocol/mod.ts';
 import { makeBrokerClient } from '../rpc-protocol/mod.ts';
 
-import { PROTOCOL_METHOD } from './protocol.ts';
+import { PROTOCOL_METHOD, PROTOCOL_PATHNAMES } from './protocol.ts';
 
 /**
  * Represents HTTP-related call options that can be passed when invoking.
@@ -30,9 +30,34 @@ export interface HTTPClientOptions extends ClientOptions<HTTPCallOptions> {
      */
     readonly http: {
         /**
-         * Represents the HTTP endpoint to request for RPC calls.
+         * Represents the hostname of the remote RPC server.
          */
-        readonly endpoint: string;
+        readonly hostname: string;
+
+        /**
+         * Represents if the remote RPC server is using HTTPS.
+         */
+        readonly https?: boolean;
+
+        /**
+         * Represents the port of the remote RPC server.
+         */
+        readonly port?: number;
+
+        /**
+         * Represents the pathname endpoints used to handle each RPC call type.
+         */
+        readonly endpoints?: {
+            /**
+             * Represents the endpoint used to handle notification calls.
+             */
+            readonly notifications?: string;
+
+            /**
+             * Represents the endpoint used to handle procedure calls.
+             */
+            readonly procedures?: string;
+        };
     };
 }
 
@@ -146,18 +171,32 @@ export function makeHTTPClient<
     options: HTTPClientOptions,
 ): HTTPClient<Notifications, Procedures> {
     const { http } = options;
-    const { endpoint } = http;
 
-    // NOTE: We do not technically need to use `new URL` here
-    // but is provides us with an upfront validation if the
-    // provided endpoint is valid.
-    const url = new URL(endpoint);
+    const {
+        endpoints = {},
+        https = false,
+        hostname,
+        port = https ? 443 : 8080,
+    } = http;
+
+    const {
+        notifications: pathname_notifications =
+            PROTOCOL_PATHNAMES.notifications,
+        procedures: pathname_procedures = PROTOCOL_PATHNAMES.procedures,
+    } = endpoints;
+
+    const url_base = new URL(
+        `${https ? 'https' : 'http'}://${hostname}:${port}`,
+    );
+
+    const url_notifications = new URL(pathname_notifications, url_base);
+    const url_procedures = new URL(pathname_procedures, url_base);
 
     const { notifications, procedures } = makeBrokerClient<Procedures>({
         ...options,
 
         processNotification: async (notification, options: HTTPCallOptions) => {
-            const response = await fetch(url, {
+            const response = await fetch(url_notifications, {
                 ...options.http,
 
                 method: PROTOCOL_METHOD,
@@ -173,7 +212,7 @@ export function makeHTTPClient<
         processProcedure: async (procedure, options: HTTPCallOptions) => {
             const { signal } = options;
 
-            const promise = fetch(url, {
+            const promise = fetch(url_procedures, {
                 ...options.http,
 
                 method: PROTOCOL_METHOD,

--- a/rpc-http/client.ts
+++ b/rpc-http/client.ts
@@ -144,10 +144,7 @@ export type HTTPClient<
  * **mod.ts**
  * ```typescript
  * import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
- * import {
- *     PROTOCOL_PATHNAME_PROCEDURES,
- *     makeHTTPClient,
- * } from 'https://deno.land/x/enzastdlib/rpc-http/mod.ts';
+ * import { makeHTTPClient } from 'https://deno.land/x/enzastdlib/rpc-http/mod.ts';
  *
  * import type { add } from './add.procedure.ts';
  *
@@ -155,7 +152,8 @@ export type HTTPClient<
  *
  * const client = makeHTTPClient<MyRPCProcedures>({
  *     http: {
- *         endpoint: `http://example.domain${PROTOCOL_PATHNAME_PROCEDURES}`,
+ *         hostname: '127.0.0.1',
+ *         port: 8080,
  *     },
  * });
  *

--- a/rpc-http/protocol.ts
+++ b/rpc-http/protocol.ts
@@ -10,13 +10,23 @@ export const PROTOCOL_METHOD = 'POST';
 /**
  * Represents the HTTP namespace pathname exclusively used by enzastdlib's RPC protocol.
  */
-export const PROTOCOL_PATHNAME = `/.enzastdlib/rpc`;
+export const PROTOCOL_NAMESPACE =
+    `/.enzastdlib/rpc/${PROTOCOL_VERSION}` as const;
 
 /**
- * Represents the HTTP pathname for procedure calls used by enzastdlib's RPC protocol.
+ * Represents a mapping of standard enzastdlib RPC call handling to HTTP pathnames.
  */
-export const PROTOCOL_PATHNAME_PROCEDURES =
-    `${PROTOCOL_PATHNAME}/procedures/${PROTOCOL_VERSION}`;
+export const PROTOCOL_PATHNAMES = {
+    /**
+     * Represents the pathname used by notification calls.
+     */
+    notifications: `${PROTOCOL_NAMESPACE}/notifications`,
+
+    /**
+     * Represents the pathname used by procedure calls.
+     */
+    procedures: `${PROTOCOL_NAMESPACE}/procedures`,
+} as const;
 
 /**
  * Represents a mapping of standard enzastdlib RPC protocol behavior to HTTP status codes.
@@ -42,9 +52,14 @@ export const PROTOCOL_RESPONSES = {
      * Represents when a client makes an RPC call with an invalid pathname.
      */
     invalid_pathname: 404,
-};
+} as const;
 
 /**
- * Represents a union of all possible HTTP status codes enzastdlib RPC protocol can emit.
+ * Represents a union of all possible HTTP status codes the enzastdlib RPC protocol can emit.
  */
 export type ProtocolResponses = ValueOf<typeof PROTOCOL_RESPONSES>;
+
+/**
+ * Represents a union of all possible HTTP pathnames used by the enzastdlib's RPC protocol.
+ */
+export type ProtocolPathnames = ValueOf<typeof PROTOCOL_PATHNAMES>;

--- a/rpc-http/test/mod.test.ts
+++ b/rpc-http/test/mod.test.ts
@@ -28,7 +28,7 @@ import {
     makeHTTPClient,
     makeHTTPServer,
     PROTOCOL_METHOD,
-    PROTOCOL_PATHNAME_PROCEDURES,
+    PROTOCOL_PATHNAMES,
     PROTOCOL_RESPONSES,
 } from '../mod.ts';
 
@@ -96,8 +96,8 @@ Deno.test(function makeHTTPClientNotificationSuccess() {
 
     const client = makeHTTPClient<EmptyObject, { log: typeof log }>({
         http: {
-            endpoint:
-                `http://${TEST_HOSTNAME}:${TEST_PORT}${PROTOCOL_PATHNAME_PROCEDURES}`,
+            hostname: TEST_HOSTNAME,
+            port: TEST_PORT,
         },
     });
 
@@ -165,8 +165,8 @@ Deno.test(async function makeHTTPClientProcedureSuccess() {
 
     const client = makeHTTPClient<{ add: typeof add }>({
         http: {
-            endpoint:
-                `http://${TEST_HOSTNAME}:${TEST_PORT}${PROTOCOL_PATHNAME_PROCEDURES}`,
+            hostname: TEST_HOSTNAME,
+            port: TEST_PORT,
         },
     });
 
@@ -234,8 +234,8 @@ Deno.test(function makeHTTPClientNotificationHTTPOptionsSuccess() {
 
     const client = makeHTTPClient<EmptyObject, { log: typeof log }>({
         http: {
-            endpoint:
-                `http://${TEST_HOSTNAME}:${TEST_PORT}${PROTOCOL_PATHNAME_PROCEDURES}`,
+            hostname: TEST_HOSTNAME,
+            port: TEST_PORT,
         },
     });
 
@@ -288,8 +288,8 @@ Deno.test(async function makeHTTPClientProcedureHTTPOptionsSuccess() {
 
     const client = makeHTTPClient<{ add: typeof add }>({
         http: {
-            endpoint:
-                `http://${TEST_HOSTNAME}:${TEST_PORT}${PROTOCOL_PATHNAME_PROCEDURES}`,
+            hostname: TEST_HOSTNAME,
+            port: TEST_PORT,
         },
     });
 
@@ -337,7 +337,7 @@ Deno.test(async function makeHTTPServerNotificationSuccess() {
     assertEquals(server.closed, false);
 
     const response = await fetch(
-        `http://${hostname}:${port}${PROTOCOL_PATHNAME_PROCEDURES}`,
+        `http://${hostname}:${port}${PROTOCOL_PATHNAMES.notifications}`,
         {
             body: JSON.stringify(
                 {
@@ -391,7 +391,7 @@ Deno.test(async function makeHTTPServerProcedureSuccess() {
     assertEquals(server.closed, false);
 
     const response = await fetch(
-        `http://${hostname}:${port}${PROTOCOL_PATHNAME_PROCEDURES}`,
+        `http://${hostname}:${port}${PROTOCOL_PATHNAMES.procedures}`,
         {
             body: JSON.stringify(
                 {
@@ -462,7 +462,7 @@ Deno.test(async function makeHTTPServerMethodFailure() {
     assertEquals(server.closed, false);
 
     const response = await fetch(
-        `http://${hostname}:${port}${PROTOCOL_PATHNAME_PROCEDURES}`,
+        `http://${hostname}:${port}${PROTOCOL_PATHNAMES.procedures}`,
         {
             body: JSON.stringify(
                 {
@@ -635,8 +635,8 @@ Deno.test(async function makeHTTPIntegrationSuccess() {
 
     const client = makeHTTPClient<{ add: typeof add }, { log: typeof log }>({
         http: {
-            endpoint:
-                `http://${hostname}:${port}${PROTOCOL_PATHNAME_PROCEDURES}`,
+            hostname: hostname,
+            port: port,
         },
     });
 


### PR DESCRIPTION
# CHANGELOG

- **BREAKING** [@enzastdlib/rpc-http] Renamed PROTOCOL_PATHNAME -> `PROTOCOL_NAMESPACE`.
- **BREAKING** [@enzastdlib/rpc-http] Refactored `PROTOCOL_PATHNAME_PROCEDURES` into an enumeration named `PROTOCOL_PATHNAMES`.

    - Pathnames now are per RPC call type rather than all call types use the same pathname.

 - **BREAKING** [@enzastdlib/rpc-http] Refactored `HTTPClientOptions.http.endpoint` into the following members:

    - `HTTPClientOptions.http.hostname` — Sets the remote hostname.
    - `HTTPClientOptions.http.https` — Sets if the connection is over HTTPS.
    - `HTTPClientOptions.http.port` — Sets the remote port.
    - `HTTPClientOptions.http.endpoints.notifications` — Sets the remote notifications endpoint.
    - `HTTPClientOptions.http.endpoints.procedures` — Sets the remote procedures endpoint.

    - This allows for simplier DX regarding configuring a client since a lot configuration can be defaulted now.

- [@enzastdlib/rpc-http] Added `ProtocolPathnames` type alias which is a union of `PROTOCOL_PATHNAMES` values.
- [@enzastdlib/rpc-http] Updated tests to follow new pathname scheme.
